### PR TITLE
모바일용 Header Component 구현

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -21,9 +21,9 @@ export default function Header({
   return (
     <div>
       {/* Logo, Title, 홈/메모/ToDo/통계/친구 */}
-      <div className="flex items-center">
+      <div className="sm:flex-col flex items-center">
         {/* Logo, Title */}
-        <div className="flex items-center">
+        <div className="sm:flex-col flex items-center">
           <div className="relative size-[6rem]">
             <Image
               src={LogoImage}
@@ -32,7 +32,7 @@ export default function Header({
               style={{ objectFit: 'contain' }}
             />
           </div>
-          <div className="ml-[1rem] relative w-[14.4rem] h-[3.2rem]">
+          <div className="ml-[1rem] relative w-[14.4rem] h-[3.2rem] sm:ml-0">
             <Image
               src={TitleImage}
               alt="TitleImage"
@@ -42,9 +42,9 @@ export default function Header({
           </div>
         </div>
         {/* 홈/메모/ToDo/통계/친구 */}
-        <div className="ml-[3.5rem] flex items-center">
+        <div className="sm:flex-col ml-[3.5rem] flex items-center sm:ml-0">
           <div
-            className={`flex justify-center items-center w-[3.3rem] h-[3.4rem]  ${isMainPage ? 'bg-navy text-white rounded-xl' : 'bg-white text-black'}`}
+            className={`sm:flex-col flex justify-center items-center w-[3.3rem] h-[3.4rem]  ${isMainPage ? 'bg-navy text-white rounded-xl' : 'bg-white text-black'}`}
           >
             <Link
               className={`font-nanumgothic_regular text-[2rem] `}
@@ -54,7 +54,7 @@ export default function Header({
             </Link>
           </div>
           <div
-            className={`flex justify-center items-center ml-[1rem] w-[5.2rem] h-[3.4rem]  ${isMemoPage ? 'bg-navy text-white rounded-xl' : 'bg-white text-black'}`}
+            className={`sm:flex-col flex justify-center items-center ml-[1rem] w-[5.2rem] h-[3.4rem]   sm:ml-0 ${isMemoPage ? 'bg-navy text-white rounded-xl' : 'bg-white text-black'}`}
           >
             <Link
               className={`font-nanumgothic_regular text-[2rem] `}
@@ -64,7 +64,7 @@ export default function Header({
             </Link>
           </div>
           <div
-            className={`flex ml-[1rem] justify-center items-center w-[6.4rem] h-[3.4rem]  ${isToDoPage ? 'bg-navy text-white rounded-xl' : 'bg-white text-black'}`}
+            className={`sm:ml-0 sm:flex-col flex ml-[1rem] justify-center items-center w-[6.4rem] h-[3.4rem]  ${isToDoPage ? 'bg-navy text-white rounded-xl' : 'bg-white text-black'}`}
           >
             <Link
               className={`font-nanumgothic_regular text-[2rem] `}
@@ -74,7 +74,7 @@ export default function Header({
             </Link>
           </div>
           <div
-            className={`flex ml-[1rem] justify-center items-center w-[5.2rem] h-[3.4rem]  ${isStatsPage ? 'bg-navy text-white rounded-xl' : 'bg-white text-black'}`}
+            className={`sm:ml-0 sm:flex-col flex ml-[1rem] justify-center items-center w-[5.2rem] h-[3.4rem]  ${isStatsPage ? 'bg-navy text-white rounded-xl' : 'bg-white text-black'}`}
           >
             <Link
               className={`font-nanumgothic_regular text-[2rem] `}
@@ -84,7 +84,7 @@ export default function Header({
             </Link>
           </div>
           <div
-            className={`flex ml-[1rem] justify-center items-center w-[5.2rem] h-[3.4rem]  ${isFriendPage ? 'bg-navy text-white rounded-xl' : 'bg-white text-black'}`}
+            className={`sm:ml-0 sm:flex-col flex ml-[1rem] justify-center items-center w-[5.2rem] h-[3.4rem]  ${isFriendPage ? 'bg-navy text-white rounded-xl' : 'bg-white text-black'}`}
           >
             <Link
               className={`font-nanumgothic_regular text-[2rem] `}

--- a/components/HeaderClients.tsx
+++ b/components/HeaderClients.tsx
@@ -13,8 +13,8 @@ export const HeaderWrapper = () => {
   const isStatsPage = router.startsWith('/stats')
   const isFriendPage = router.startsWith('/friend')
   return (
-    <header className="flex justify-center">
-      <div className=" w-[100rem] h-[8.6rem] flex justify-between items-center">
+    <header className="flex justify-center sm:flex-col">
+      <div className="w-[100rem] h-[8.6rem] flex sm:flex-col justify-between items-center sm:w-full sm:h-[32rem]">
         <Header
           isMainPage={isMainPage}
           isMemoPage={isMemoPage}
@@ -22,11 +22,11 @@ export const HeaderWrapper = () => {
           isStatsPage={isStatsPage}
           isFriendPage={isFriendPage}
         />
-        <div>
+        <div className="flex sm:flex-col">
           <HeaderNaverAuth />
           {/* Dark */}
           <button
-            className="font-nanumgothic_regular text-[2rem] ml-[1.5rem]"
+            className="font-nanumgothic_regular text-[2rem] ml-[1.5rem] sm:ml-0"
             type="button"
           >
             Dark
@@ -47,22 +47,22 @@ export const HeaderNaverAuth = () => {
     signOut().catch((error) => console.error('로그아웃 실패:', error))
   }
   return (
-    <>
+    <div className="sm:flex-col">
       {session ? (
         <button
-          className="font-nanumgothic_regular text-[2rem] ml-[1.5rem]"
+          className="font-nanumgothic_regular text-[2rem] ml-[1.5rem] sm:ml-0"
           onClick={handleSignOut}
         >
           로그아웃
         </button>
       ) : (
         <button
-          className="font-nanumgothic_regular text-[2rem] ml-[1.5rem]"
+          className="font-nanumgothic_regular text-[2rem] ml-[1.5rem] sm:ml-0"
           onClick={handleSignIn}
         >
           로그인
         </button>
       )}
-    </>
+    </div>
   )
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,9 @@ export default {
     './src/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
+    screens: {
+      sm: { max: '1104px' },
+    },
     extend: {
       colors: {
         navy: '#003366',


### PR DESCRIPTION
## 개요

- 간단한 내용 작성

## #️⃣연관된 이슈
#7 

## PR 유형

- [ ] API 설정 & 통신
- [ ] 버그를 수정
- [ ] 기타 수정(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] CSS 등 사용자 UI 디자인 변경(마크업 & 스타일링)
- [ ] 문서 수정
- [ ] 새로운 기능을 개발
- [ ] 코드 리팩토링
- [x] 세팅을 변경, 추가, 삭제

## 📝작업 내용
- tailwind 설정에 모바일 사이즈 추가 : 1104 
- 기본 Header가 적절하게 보일 수 있는 크기의 최소가 1105이기 때문
- 모바일용 사이즈의 따른 Header 디자인 변화
![1](https://github.com/user-attachments/assets/06c99be1-b9a0-43ac-bc39-dccff28957fd)