### PR TITLE
Todo page의 나머지 기능 구현과 UI 구현

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+interface ButtonProps {
+  children: React.ReactNode
+  onClick?: () => void
+  className?: string
+  type: 'button' | 'submit' | 'reset'
+}
+
+export default function Button({
+  children,
+  onClick,
+  type,
+  className,
+  ...props
+}: ButtonProps) {
+  return (
+    <button type={type}>
+      <div {...props} className={`${className}`} onClick={onClick}>
+        {children}
+      </div>
+    </button>
+  )
+}

--- a/components/Loading.tsx
+++ b/components/Loading.tsx
@@ -1,0 +1,3 @@
+export default function LoadingPage() {
+  return <div className="text-center h-[30rem]">로딩중이에용</div>
+}

--- a/components/ToDo/Calendar.tsx
+++ b/components/ToDo/Calendar.tsx
@@ -1,0 +1,58 @@
+'use client'
+import FullCalendar from '@fullcalendar/react'
+import dayGridPlugin from '@fullcalendar/daygrid'
+import interactionPlugin from '@fullcalendar/interaction'
+import { EventChangeArg } from '@fullcalendar/core'
+import { useEffect, useState } from 'react'
+import { Todo, updateTodo } from './todosServer'
+import { useSession } from 'next-auth/react'
+import { EventInput } from '@fullcalendar/core'
+
+interface CalendarProps {
+  todos: Todo[]
+  setTodos: React.Dispatch<React.SetStateAction<Todo[]>>
+}
+
+export default function Calendar({ todos, setTodos }: CalendarProps) {
+  const { data: session } = useSession()
+  const [events, setEvents] = useState<EventInput[]>([])
+
+  useEffect(() => {
+    setEvents(
+      todos
+        .filter((todo: Todo) => todo.date)
+        .map((todo: Todo) => ({
+          id: todo.id,
+          title: todo.task,
+          start: todo.date ? new Date(todo.date) : undefined,
+        }))
+    )
+  }, [todos])
+
+  const handleEventDrop = async (eventDropInfo: EventChangeArg) => {
+    const todoId = eventDropInfo.event.id
+    if (!todoId || !session?.user?.email) return
+
+    const updatedDate = eventDropInfo.event.startStr
+    try {
+      await updateTodo(todoId, { date: updatedDate }, session.user.email)
+      setTodos((prevTodos) =>
+        prevTodos.map((todo: Todo) =>
+          todo.id === todoId ? { ...todo, date: updatedDate } : todo
+        )
+      )
+    } catch (error) {
+      console.log('Error updating date:', error)
+    }
+  }
+  return (
+    <FullCalendar
+      plugins={[dayGridPlugin, interactionPlugin]}
+      initialView="dayGridMonth"
+      events={events}
+      editable={true}
+      droppable={true}
+      eventDrop={handleEventDrop}
+    />
+  )
+}

--- a/components/ToDo/Calendar.tsx
+++ b/components/ToDo/Calendar.tsx
@@ -2,11 +2,12 @@
 import FullCalendar from '@fullcalendar/react'
 import dayGridPlugin from '@fullcalendar/daygrid'
 import interactionPlugin from '@fullcalendar/interaction'
-import { EventChangeArg } from '@fullcalendar/core'
-import { useEffect, useState } from 'react'
+import { EventChangeArg, EventInput } from '@fullcalendar/core'
+import { useEffect, useState, useRef } from 'react'
 import { Todo, updateTodo } from './todosServer'
 import { useSession } from 'next-auth/react'
-import { EventInput } from '@fullcalendar/core'
+import { useDrop } from 'react-dnd'
+import { DayCellMountArg } from '@fullcalendar/core'
 
 interface CalendarProps {
   todos: Todo[]
@@ -16,7 +17,66 @@ interface CalendarProps {
 export default function Calendar({ todos, setTodos }: CalendarProps) {
   const { data: session } = useSession()
   const [events, setEvents] = useState<EventInput[]>([])
+  const calendarAllDayRef = useRef<HTMLTableCellElement[]>([])
+  const calendarDropRef = useRef<HTMLDivElement>(null)
 
+  // Todo의 날짜 update
+  const handleDrop = async (calendarDroppedDate: string, todoId: string) => {
+    if (!todoId || !session?.user?.email) return
+    try {
+      await updateTodo(
+        todoId,
+        { date: calendarDroppedDate },
+        session.user.email
+      )
+      setTodos((prevTodos) =>
+        prevTodos.map((todo: Todo) =>
+          todo.id === todoId ? { ...todo, date: calendarDroppedDate } : todo
+        )
+      )
+    } catch (error) {
+      console.log('Error updating date:', error)
+    }
+  }
+
+  // 특정 todo가 캘린더에 드롭된 좌표를 통해 날짜를 찾아, todo와 캘린더를 update
+  const [{ isOver }, drop] = useDrop(() => ({
+    accept: 'TODO',
+    drop: (item: { id: string }, monitor) => {
+      // calendarDropDayInfo : 캘린더에 드롭된 좌표 반환
+      const calendarDroppedInfo = monitor.getClientOffset()
+      if (calendarDroppedInfo) {
+        const dropX = calendarDroppedInfo.x
+        const dropY = calendarDroppedInfo.y
+        const calendarDroppedPoint = calendarAllDayRef.current.find((point) => {
+          if (!point) return false
+          const rect = point.getBoundingClientRect()
+          return (
+            dropX >= rect.left &&
+            dropX <= rect.right &&
+            dropY >= rect.top &&
+            dropY <= rect.bottom
+          )
+        })
+        if (calendarDroppedPoint) {
+          const calendarDroppedDate = calendarDroppedPoint.dataset.date
+          if (calendarDroppedDate) {
+            handleDrop(calendarDroppedDate, item.id)
+          }
+        }
+      }
+    },
+    collect: (monitor) => ({
+      isOver: monitor.isOver(),
+    }),
+  }))
+
+  // drop 함수가 변경될 때마다 calendarDropRef.current에 연결
+  useEffect(() => {
+    drop(calendarDropRef.current)
+  }, [drop])
+
+  // todos 배열이 변경될 때마다 캘린더에 표시할 events 배열을 업데이트
   useEffect(() => {
     setEvents(
       todos
@@ -29,6 +89,7 @@ export default function Calendar({ todos, setTodos }: CalendarProps) {
     )
   }, [todos])
 
+  // 캘린더 내에서 todo를 드래그앤드롭했을 때 todo와 calendar를 upate하는 함수
   const handleEventDrop = async (eventDropInfo: EventChangeArg) => {
     const todoId = eventDropInfo.event.id
     if (!todoId || !session?.user?.email) return
@@ -45,14 +106,31 @@ export default function Calendar({ todos, setTodos }: CalendarProps) {
       console.log('Error updating date:', error)
     }
   }
+
+  // DayCellMountArg : FullCalendar에서 제공하는 날짜 셀에 대한 정보
+  const handleDayCellDidMount = (info: DayCellMountArg) => {
+    calendarAllDayRef.current.push(info.el as HTMLTableCellElement)
+    // info.el.dataset.date : info에서 날짜만 추출
+    info.el.dataset.date = info.date.toISOString().split('T')[0]
+  }
+
+  useEffect(() => {
+    return () => {
+      calendarAllDayRef.current = []
+    }
+  }, [])
+
   return (
-    <FullCalendar
-      plugins={[dayGridPlugin, interactionPlugin]}
-      initialView="dayGridMonth"
-      events={events}
-      editable={true}
-      droppable={true}
-      eventDrop={handleEventDrop}
-    />
+    <div ref={calendarDropRef} className={isOver ? 'bg-gray-200' : ''}>
+      <FullCalendar
+        plugins={[dayGridPlugin, interactionPlugin]}
+        initialView="dayGridMonth"
+        events={events}
+        editable={true}
+        droppable={true}
+        eventDrop={handleEventDrop}
+        dayCellDidMount={handleDayCellDidMount}
+      />
+    </div>
   )
 }

--- a/components/ToDo/Calendar.tsx
+++ b/components/ToDo/Calendar.tsx
@@ -12,9 +12,14 @@ import { DayCellMountArg } from '@fullcalendar/core'
 interface CalendarProps {
   todos: Todo[]
   setTodos: React.Dispatch<React.SetStateAction<Todo[]>>
+  onDateClick?: (date: string) => void
 }
 
-export default function Calendar({ todos, setTodos }: CalendarProps) {
+export default function Calendar({
+  todos,
+  setTodos,
+  onDateClick,
+}: CalendarProps) {
   const { data: session } = useSession()
   const [events, setEvents] = useState<EventInput[]>([])
   const calendarAllDayRef = useRef<HTMLTableCellElement[]>([])
@@ -134,7 +139,6 @@ export default function Calendar({ todos, setTodos }: CalendarProps) {
 
   return (
     <div ref={calendarDropRef}>
-      {/* <div ref={calendarDropRef} className={isOver ? 'bg-gray-200' : ''}> */}
       <FullCalendar
         plugins={[dayGridPlugin, interactionPlugin]}
         initialView="dayGridMonth"
@@ -143,6 +147,10 @@ export default function Calendar({ todos, setTodos }: CalendarProps) {
         droppable={true}
         eventDrop={handleEventDrop}
         dayCellDidMount={handleDayCellDidMount}
+        dateClick={(info) => {
+          const clickedDate = info.dateStr
+          onDateClick?.(clickedDate)
+        }}
       />
     </div>
   )

--- a/components/ToDo/NoDateTodos.tsx
+++ b/components/ToDo/NoDateTodos.tsx
@@ -2,11 +2,11 @@ import React, { useRef, useEffect } from 'react'
 import { useDrag } from 'react-dnd'
 import { Todo } from './todosServer'
 
-interface TodoItemProps {
+interface NoDateTodosProps {
   todo: Todo
 }
 
-export default function TodoItem({ todo }: TodoItemProps) {
+export default function NoDateTodos({ todo }: NoDateTodosProps) {
   const todoRef = useRef<HTMLDivElement>(null)
 
   const [{ isDragging }, drag] = useDrag(() => ({
@@ -21,7 +21,9 @@ export default function TodoItem({ todo }: TodoItemProps) {
       drag(todoRef.current)
     }
   }, [drag])
-
+  if (todo.date) {
+    return null
+  }
   return (
     <div
       ref={todoRef}

--- a/components/ToDo/NoDateTodos.tsx
+++ b/components/ToDo/NoDateTodos.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect } from 'react'
 import { useDrag } from 'react-dnd'
 import { Todo } from './todosServer'
+import TodoBox from './TodoBox'
 
 interface NoDateTodosProps {
   todo: Todo
@@ -25,11 +26,8 @@ export default function NoDateTodos({ todo }: NoDateTodosProps) {
     return null
   }
   return (
-    <div
-      ref={todoRef}
-      className={`text-green-300 {isDragging ? 'opacity-50' : 'opacity-100'}`}
-    >
-      {todo.task}
+    <div ref={todoRef}>
+      <TodoBox todo={todo} isDragging={isDragging} />
     </div>
   )
 }

--- a/components/ToDo/ToDos.tsx
+++ b/components/ToDo/ToDos.tsx
@@ -14,6 +14,8 @@ import Calendar from './Calendar'
 import NoDateTodos from './NoDateTodos'
 import { formatDate, todayDateFormat } from './TodayDateFormat'
 import TodoBox from './TodoBox'
+import LoadingPage from '../Loading'
+import Button from '../Button'
 
 export default function ToDos() {
   const { data: session } = useSession()
@@ -26,6 +28,8 @@ export default function ToDos() {
   const [newDate, setNewDate] = useState<string | null>(null)
   const [editTodo, setEditTodo] = useState<Todo | null>(null)
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
+  const [selectedPrevDate, setSelectedPrevDate] = useState<string | null>(null)
+  const [selectedNextDate, setSelectedNextDate] = useState<string | null>(null)
   const [threeDaysTodos, setThreeDaysTodos] = useState<Todo[]>([])
   const [todayTodos, setTodayTodos] = useState<Todo[]>([])
 
@@ -54,8 +58,11 @@ export default function ToDos() {
 
           targetPrevDate.setDate(targetDate.getDate() - 1)
           const targetPrevDateFormat = formatDate(targetPrevDate)
+          setSelectedPrevDate(targetPrevDateFormat)
+
           targetNextDate.setDate(targetDate.getDate() + 1)
           const targetNextDateFormat = formatDate(targetNextDate)
+          setSelectedNextDate(targetNextDateFormat)
 
           const todos = await fetchThreeDaysTodo(
             session.user.email,
@@ -159,50 +166,72 @@ export default function ToDos() {
     setNewDate(null)
   }
 
-  if (loading) return <p className="text-green-400">로딩 중</p>
+  if (loading) return <LoadingPage />
   if (error) return <p>{error}</p>
 
   return (
     <div className="flex">
       <div>
         {/* 오늘의 Todo */}
-        <div>
-          <h1>오늘({todayDateFormat()})의 Todo</h1>
-          <div className="flex flex-wrap w-[15rem]">
+        <div className="mt-[2rem] outline-offset-[1rem] outline rounded-md">
+          <div className="text-[2rem]">오늘({todayDateFormat()})의 Todo</div>
+          <div className="flex flex-wrap w-[40rem]">
             {todayTodos.length === 0 ? (
-              <div>할일없서</div>
+              <div>🍀오늘은 할일이 없네용🍀</div>
             ) : (
               todayTodos.map((todo) => <TodoBox key={todo.id} todo={todo} />)
             )}
           </div>
         </div>
-        {/* 드래그 가능 TodoList */}
-        <div className="flex flex-wrap w-[15rem]">
-          {todos.map((todo) => (
-            <NoDateTodos key={todo.id} todo={todo} /> // NoDateTodos 사용
-          ))}
+        {/* 드래그 가능한 날짜없는 TodoList */}
+        <div className="mt-[3.5rem] outline-offset-[1rem] outline rounded-md">
+          <div className="text-[2rem]">날짜없는 Todo</div>
+          <div>
+            날짜를 설정하고 싶다면, 캘린더로&nbsp;
+            <span className="font-bold text-[1.3rem]">드래그앤드롭</span>해용
+          </div>
+          <div className="flex flex-wrap w-[40rem]">
+            {todos.length === 0 ? (
+              <div>🌻모든 Todo의 날짜가 있네용🌻</div>
+            ) : (
+              todos.map((todo) => (
+                <NoDateTodos key={todo.id} todo={todo} /> // NoDateTodos 사용
+              ))
+            )}
+          </div>
         </div>
         {/* 캘린더에서 선택한 날짜의 전날, 당일, 다음날의 Todo */}
-        <div>
-          {!selectedDate && <div>날짜를 선택해</div>}
+        <div className="mt-[3.5rem] outline-offset-[1rem] outline rounded-md">
+          <div>선택한 날짜의 전날, 당일, 다음날의 Todo를 보여줄게용</div>
+          {!selectedDate && (
+            <div>
+              <div className="text-[2rem]">
+                캘린더에서 Todo를 보고싶은 날짜를 선택해용
+              </div>
+            </div>
+          )}
           {selectedDate && (
             <div>
-              <h1 className="text-green-400">{selectedDate} Todo</h1>
-              {threeDaysTodos.length === 0 ? (
-                <div>할일없서</div>
-              ) : (
-                threeDaysTodos.map((todo) => (
-                  <TodoBox key={todo.id} todo={todo} />
-                ))
-              )}
+              <div className="text-[2rem]">
+                {selectedPrevDate},{selectedDate},{selectedNextDate}의 Todo
+              </div>
+              <div className="flex flex-wrap w-[40rem]">
+                {threeDaysTodos.length === 0 ? (
+                  <div>🍀{selectedDate} 전후로는 할일이 없네용🍀</div>
+                ) : (
+                  threeDaysTodos.map((todo) => (
+                    <TodoBox key={todo.id} todo={todo} />
+                  ))
+                )}
+              </div>
             </div>
           )}
         </div>
-        {/* 로그인한 사용자의 전체 Todo List */}
-        <div>
-          <h1 className="text-green-400">Todo List</h1>
+        {/* Todo 추가/삭제 Input */}
+        <div className="mt-[3.5rem] outline-offset-[1rem] outline rounded-md text-[1.5rem]">
+          <div className="text-[2rem]">Todo 추가/삭제</div>
           <input
-            className="w-[30rem] text-black"
+            className="w-[30rem] text-black mb-[1rem]"
             type="text"
             value={newTask}
             placeholder="새로운 ToDo를 추가하세요"
@@ -210,24 +239,29 @@ export default function ToDos() {
           />
           <div>
             <label>
-              중요도 :
+              중요도
               <input
                 type="checkbox"
                 checked={newImportant}
+                className="size-[1.4rem]"
                 onChange={(e) => setNewImportant(e.target.checked)}
               />
             </label>
-            <label>
-              완료 :
+            <label className="ml-[2rem]">
+              완료
               <input
                 type="checkbox"
                 checked={newCompleted}
+                className="size-[1.4rem]"
                 onChange={(e) => setNewCompleted(e.target.checked)}
               />
             </label>
             {editTodo && (
               <div>
-                기존 날짜 : <span>{editTodo.date || '없음'}</span>
+                기존 날짜 :{' '}
+                <span>
+                  {editTodo.date ? formatDate(new Date(editTodo.date)) : '없음'}
+                </span>
               </div>
             )}
             <label>
@@ -240,41 +274,65 @@ export default function ToDos() {
               />
             </label>
             {editTodo && (
-              <button type="button" onClick={handleClearDate}>
+              <Button
+                type="button"
+                onClick={handleClearDate}
+                className="ml-[2rem] w-[8rem] bg-blue-800"
+              >
                 날짜 미정
-              </button>
+              </Button>
             )}
             {editTodo ? (
-              <button type="button" onClick={updateTodoInput}>
+              <Button
+                type="button"
+                onClick={updateTodoInput}
+                className="ml-[2rem] w-[5rem] bg-blue-800"
+              >
                 수정
-              </button>
+              </Button>
             ) : (
-              <button type="button" onClick={handleAddTodo}>
+              <Button
+                type="button"
+                onClick={handleAddTodo}
+                className="ml-[2rem] w-[5rem] bg-blue-800"
+              >
                 추가
-              </button>
+              </Button>
             )}
           </div>
-
-          <div>
+        </div>
+        {/* 로그인한 사용자의 전체 Todo List */}
+        <div className="mt-[3.5rem] outline-offset-[1rem] outline rounded-md">
+          <div className="text-[2rem]">{session?.user?.name}의Todo List</div>
+          <div className="flex flex-wrap w-[40rem]">
             {todos.map((todo) => (
-              <div key={todo.id}>
+              <div key={todo.id} className="h-[14rem]">
                 <TodoBox key={todo.id} todo={todo} />
-                <button
-                  type="button"
-                  onClick={() => {
-                    handleEditTodo(todo)
-                  }}
-                >
-                  수정
-                </button>
-                <button onClick={() => handleDeleteTodo(todo.id)}>삭제</button>
+                <div className="items-center justify-center flex mt-[0.5rem]">
+                  <Button
+                    type="button"
+                    onClick={() => {
+                      handleEditTodo(todo)
+                    }}
+                  >
+                    수정
+                  </Button>
+                  <Button
+                    type="button"
+                    className="ml-[2rem]"
+                    onClick={() => handleDeleteTodo(todo.id)}
+                  >
+                    삭제
+                  </Button>
+                </div>
               </div>
             ))}
           </div>
         </div>
+        <div className="mb-[2rem]"></div>
       </div>
       {/* 캘린더 */}
-      <div className="size-[50rem]">
+      <div className="ml-[3rem] size-[50rem]">
         <Calendar
           todos={todos}
           setTodos={setTodos}

--- a/components/ToDo/ToDos.tsx
+++ b/components/ToDo/ToDos.tsx
@@ -116,7 +116,7 @@ export default function ToDos() {
     <div className="flex">
       <div>
         {/* 드래그 가능 TodoList */}
-        <div>
+        <div className="flex flex-wrap w-[15rem]">
           {todos.map((todo) => (
             <NoDateTodos key={todo.id} todo={todo} /> // NoDateTodos 사용
           ))}
@@ -131,50 +131,53 @@ export default function ToDos() {
             placeholder="새로운 ToDo를 추가하세요"
             onChange={(e) => setNewTask(e.target.value)}
           />
-          <label>
-            중요도 :
-            <input
-              type="checkbox"
-              checked={newImportant}
-              onChange={(e) => setNewImportant(e.target.checked)}
-            />
-          </label>
-          <label>
-            완료 :
-            <input
-              type="checkbox"
-              checked={newCompleted}
-              onChange={(e) => setNewCompleted(e.target.checked)}
-            />
-          </label>
-          {editTodo && (
-            <div>
-              기존 날짜 : <span>{editTodo.date || '없음'}</span>
-            </div>
-          )}
-          <label>
-            날짜 :
-            <input
-              className="text-black"
-              type="date"
-              value={newDate || ''}
-              onChange={(e) => setNewDate(e.target.value || null)}
-            />
-          </label>
-          {editTodo && (
-            <button type="button" onClick={handleClearDate}>
-              날짜 미정
-            </button>
-          )}
-          {editTodo ? (
-            <button type="button" onClick={updateTodoInput}>
-              수정
-            </button>
-          ) : (
-            <button type="button" onClick={handleAddTodo}>
-              추가
-            </button>
-          )}
+          <div>
+            <label>
+              중요도 :
+              <input
+                type="checkbox"
+                checked={newImportant}
+                onChange={(e) => setNewImportant(e.target.checked)}
+              />
+            </label>
+            <label>
+              완료 :
+              <input
+                type="checkbox"
+                checked={newCompleted}
+                onChange={(e) => setNewCompleted(e.target.checked)}
+              />
+            </label>
+            {editTodo && (
+              <div>
+                기존 날짜 : <span>{editTodo.date || '없음'}</span>
+              </div>
+            )}
+            <label>
+              날짜 :
+              <input
+                className="text-black"
+                type="date"
+                value={newDate || ''}
+                onChange={(e) => setNewDate(e.target.value || null)}
+              />
+            </label>
+            {editTodo && (
+              <button type="button" onClick={handleClearDate}>
+                날짜 미정
+              </button>
+            )}
+            {editTodo ? (
+              <button type="button" onClick={updateTodoInput}>
+                수정
+              </button>
+            ) : (
+              <button type="button" onClick={handleAddTodo}>
+                추가
+              </button>
+            )}
+          </div>
+
           <div>
             {todos.map((todo) => (
               <div key={todo.id}>

--- a/components/ToDo/ToDos.tsx
+++ b/components/ToDo/ToDos.tsx
@@ -8,6 +8,7 @@ import {
   fetchTodos,
   updateTodo,
 } from './todosServer'
+import Calendar from './Calendar'
 
 export default function ToDos() {
   const { data: session } = useSession()
@@ -111,81 +112,86 @@ export default function ToDos() {
   if (error) return <p>{error}</p>
 
   return (
-    <>
-      <h1 className="text-green-400">Todo List</h1>
-      <input
-        className="w-[30rem] text-black"
-        type="text"
-        value={newTask}
-        placeholder="새로운 ToDo를 추가하세요"
-        onChange={(e) => setNewTask(e.target.value)}
-      />
-      <label>
-        중요도 :
-        <input
-          type="checkbox"
-          checked={newImportant}
-          onChange={(e) => setNewImportant(e.target.checked)}
-        />
-      </label>
-      <label>
-        완료 :
-        <input
-          type="checkbox"
-          checked={newCompleted}
-          onChange={(e) => setNewCompleted(e.target.checked)}
-        />
-      </label>
-      {editTodo && (
-        <div>
-          기존 날짜 : <span>{editTodo.date || '없음'}</span>
-        </div>
-      )}
-      <label>
-        날짜 :
-        <input
-          className="text-black"
-          type="date"
-          value={newDate || ''}
-          onChange={(e) => setNewDate(e.target.value || null)}
-        />
-      </label>
-      {editTodo && (
-        <button type="button" onClick={handleClearDate}>
-          날짜 미정
-        </button>
-      )}
-      {editTodo ? (
-        <button type="button" onClick={updateTodoInput}>
-          수정
-        </button>
-      ) : (
-        <button type="button" onClick={handleAddTodo}>
-          추가
-        </button>
-      )}
+    <div className="flex">
       <div>
-        {todos.map((todo) => (
-          <div key={todo.id}>
-            <div>todo id : {todo.id}</div>
-            <div>todo user-id : {todo.user_email}</div>
-            <div>task : {todo.task}</div>
-            <div>completed : {todo.completed ? 'true' : 'false'}</div>
-            <div>date : {todo.date}</div>
-            <div>memo_id : {todo.memo_id}</div>
-            <div>important : {todo.important ? 'true' : 'false'}</div>
-            <button
-              type="button"
-              onClick={() => {
-                handleEditTodo(todo)
-              }}
-            >
-              수정
-            </button>
-            <button onClick={() => handleDeleteTodo(todo.id)}>삭제</button>
+        <h1 className="text-green-400">Todo List</h1>
+        <input
+          className="w-[30rem] text-black"
+          type="text"
+          value={newTask}
+          placeholder="새로운 ToDo를 추가하세요"
+          onChange={(e) => setNewTask(e.target.value)}
+        />
+        <label>
+          중요도 :
+          <input
+            type="checkbox"
+            checked={newImportant}
+            onChange={(e) => setNewImportant(e.target.checked)}
+          />
+        </label>
+        <label>
+          완료 :
+          <input
+            type="checkbox"
+            checked={newCompleted}
+            onChange={(e) => setNewCompleted(e.target.checked)}
+          />
+        </label>
+        {editTodo && (
+          <div>
+            기존 날짜 : <span>{editTodo.date || '없음'}</span>
           </div>
-        ))}
+        )}
+        <label>
+          날짜 :
+          <input
+            className="text-black"
+            type="date"
+            value={newDate || ''}
+            onChange={(e) => setNewDate(e.target.value || null)}
+          />
+        </label>
+        {editTodo && (
+          <button type="button" onClick={handleClearDate}>
+            날짜 미정
+          </button>
+        )}
+        {editTodo ? (
+          <button type="button" onClick={updateTodoInput}>
+            수정
+          </button>
+        ) : (
+          <button type="button" onClick={handleAddTodo}>
+            추가
+          </button>
+        )}
+        <div>
+          {todos.map((todo) => (
+            <div key={todo.id}>
+              <div>todo id : {todo.id}</div>
+              <div>todo user-id : {todo.user_email}</div>
+              <div>task : {todo.task}</div>
+              <div>completed : {todo.completed ? 'true' : 'false'}</div>
+              <div>date : {todo.date}</div>
+              <div>memo_id : {todo.memo_id}</div>
+              <div>important : {todo.important ? 'true' : 'false'}</div>
+              <button
+                type="button"
+                onClick={() => {
+                  handleEditTodo(todo)
+                }}
+              >
+                수정
+              </button>
+              <button onClick={() => handleDeleteTodo(todo.id)}>삭제</button>
+            </div>
+          ))}
+        </div>
       </div>
-    </>
+      <div className="size-[50rem]">
+        <Calendar todos={todos} setTodos={setTodos} />
+      </div>
+    </div>
   )
 }

--- a/components/ToDo/ToDos.tsx
+++ b/components/ToDo/ToDos.tsx
@@ -9,6 +9,7 @@ import {
   updateTodo,
 } from './todosServer'
 import Calendar from './Calendar'
+import TodoItem from './TodoItem'
 
 export default function ToDos() {
   const { data: session } = useSession()
@@ -114,81 +115,91 @@ export default function ToDos() {
   return (
     <div className="flex">
       <div>
-        <h1 className="text-green-400">Todo List</h1>
-        <input
-          className="w-[30rem] text-black"
-          type="text"
-          value={newTask}
-          placeholder="새로운 ToDo를 추가하세요"
-          onChange={(e) => setNewTask(e.target.value)}
-        />
-        <label>
-          중요도 :
-          <input
-            type="checkbox"
-            checked={newImportant}
-            onChange={(e) => setNewImportant(e.target.checked)}
-          />
-        </label>
-        <label>
-          완료 :
-          <input
-            type="checkbox"
-            checked={newCompleted}
-            onChange={(e) => setNewCompleted(e.target.checked)}
-          />
-        </label>
-        {editTodo && (
-          <div>
-            기존 날짜 : <span>{editTodo.date || '없음'}</span>
-          </div>
-        )}
-        <label>
-          날짜 :
-          <input
-            className="text-black"
-            type="date"
-            value={newDate || ''}
-            onChange={(e) => setNewDate(e.target.value || null)}
-          />
-        </label>
-        {editTodo && (
-          <button type="button" onClick={handleClearDate}>
-            날짜 미정
-          </button>
-        )}
-        {editTodo ? (
-          <button type="button" onClick={updateTodoInput}>
-            수정
-          </button>
-        ) : (
-          <button type="button" onClick={handleAddTodo}>
-            추가
-          </button>
-        )}
+        {/* 드래그 가능 TodoList */}
         <div>
           {todos.map((todo) => (
-            <div key={todo.id}>
-              <div>todo id : {todo.id}</div>
-              <div>todo user-id : {todo.user_email}</div>
-              <div>task : {todo.task}</div>
-              <div>completed : {todo.completed ? 'true' : 'false'}</div>
-              <div>date : {todo.date}</div>
-              <div>memo_id : {todo.memo_id}</div>
-              <div>important : {todo.important ? 'true' : 'false'}</div>
-              <button
-                type="button"
-                onClick={() => {
-                  handleEditTodo(todo)
-                }}
-              >
-                수정
-              </button>
-              <button onClick={() => handleDeleteTodo(todo.id)}>삭제</button>
-            </div>
+            <TodoItem key={todo.id} todo={todo} /> // TodoItem 사용
           ))}
         </div>
+        {/* 처음 Todo List */}
+        <div>
+          <h1 className="text-green-400">Todo List</h1>
+          <input
+            className="w-[30rem] text-black"
+            type="text"
+            value={newTask}
+            placeholder="새로운 ToDo를 추가하세요"
+            onChange={(e) => setNewTask(e.target.value)}
+          />
+          <label>
+            중요도 :
+            <input
+              type="checkbox"
+              checked={newImportant}
+              onChange={(e) => setNewImportant(e.target.checked)}
+            />
+          </label>
+          <label>
+            완료 :
+            <input
+              type="checkbox"
+              checked={newCompleted}
+              onChange={(e) => setNewCompleted(e.target.checked)}
+            />
+          </label>
+          {editTodo && (
+            <div>
+              기존 날짜 : <span>{editTodo.date || '없음'}</span>
+            </div>
+          )}
+          <label>
+            날짜 :
+            <input
+              className="text-black"
+              type="date"
+              value={newDate || ''}
+              onChange={(e) => setNewDate(e.target.value || null)}
+            />
+          </label>
+          {editTodo && (
+            <button type="button" onClick={handleClearDate}>
+              날짜 미정
+            </button>
+          )}
+          {editTodo ? (
+            <button type="button" onClick={updateTodoInput}>
+              수정
+            </button>
+          ) : (
+            <button type="button" onClick={handleAddTodo}>
+              추가
+            </button>
+          )}
+          <div>
+            {todos.map((todo) => (
+              <div key={todo.id}>
+                <div>todo id : {todo.id}</div>
+                <div>todo user-id : {todo.user_email}</div>
+                <div>task : {todo.task}</div>
+                <div>completed : {todo.completed ? 'true' : 'false'}</div>
+                <div>date : {todo.date}</div>
+                <div>memo_id : {todo.memo_id}</div>
+                <div>important : {todo.important ? 'true' : 'false'}</div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    handleEditTodo(todo)
+                  }}
+                >
+                  수정
+                </button>
+                <button onClick={() => handleDeleteTodo(todo.id)}>삭제</button>
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
+
       <div className="size-[50rem]">
         <Calendar todos={todos} setTodos={setTodos} />
       </div>

--- a/components/ToDo/ToDos.tsx
+++ b/components/ToDo/ToDos.tsx
@@ -9,7 +9,7 @@ import {
   updateTodo,
 } from './todosServer'
 import Calendar from './Calendar'
-import TodoItem from './TodoItem'
+import NoDateTodos from './NoDateTodos'
 
 export default function ToDos() {
   const { data: session } = useSession()
@@ -118,7 +118,7 @@ export default function ToDos() {
         {/* 드래그 가능 TodoList */}
         <div>
           {todos.map((todo) => (
-            <TodoItem key={todo.id} todo={todo} /> // TodoItem 사용
+            <NoDateTodos key={todo.id} todo={todo} /> // NoDateTodos 사용
           ))}
         </div>
         {/* 처음 Todo List */}

--- a/components/ToDo/TodayDateFormat.tsx
+++ b/components/ToDo/TodayDateFormat.tsx
@@ -1,0 +1,6 @@
+export const formatDate = (d: Date) => d.toISOString().split('T')[0]
+
+export const todayDateFormat = () => {
+  const today = new Date()
+  return formatDate(today)
+}

--- a/components/ToDo/TodoBox.tsx
+++ b/components/ToDo/TodoBox.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Todo } from './todosServer'
+
+interface TodoBoxProps {
+  todo: Todo
+  isDragging: boolean
+}
+
+export default function TodoBox({ todo, isDragging }: TodoBoxProps) {
+  return (
+    <div
+      className={`size-[5rem] rounded-md text-center border-[0.5rem] border-purple-500 ${isDragging ? 'text-green-300' : 'text-white'}`}
+    >
+      {todo.task}
+    </div>
+  )
+}

--- a/components/ToDo/TodoBox.tsx
+++ b/components/ToDo/TodoBox.tsx
@@ -1,22 +1,27 @@
 import React from 'react'
 import { Todo } from './todosServer'
-
+import { formatDate } from './TodayDateFormat'
 interface TodoBoxProps {
   todo: Todo
   isDragging?: boolean
 }
 
 export default function TodoBox({ todo, isDragging }: TodoBoxProps) {
+  console.log(todo.date)
+  const formattedDate = todo.date ? formatDate(new Date(todo.date)) : '날짜없음'
+
   return (
     <div
-      className={`size-[5rem] rounded-md text-center border-[0.5rem] border-purple-500 ${isDragging ? 'text-green-300' : 'text-white'}`}
+      className={`size-[10rem] rounded-lg flex justify-center items-center text-center mx-[1.5rem] bg-blue-800  ${isDragging ? 'text-green-300' : 'text-white'}`}
     >
       <div>
         {todo.task}
+        <br />
         {todo.completed ? '완료✅' : '아직❌'}
         {todo.important ? '중요⭐' : '보통🌊'}
+        <br />
+        {`날짜: ${formattedDate}`}
       </div>
-      <div></div>
     </div>
   )
 }

--- a/components/ToDo/TodoBox.tsx
+++ b/components/ToDo/TodoBox.tsx
@@ -3,7 +3,7 @@ import { Todo } from './todosServer'
 
 interface TodoBoxProps {
   todo: Todo
-  isDragging: boolean
+  isDragging?: boolean
 }
 
 export default function TodoBox({ todo, isDragging }: TodoBoxProps) {
@@ -11,7 +11,12 @@ export default function TodoBox({ todo, isDragging }: TodoBoxProps) {
     <div
       className={`size-[5rem] rounded-md text-center border-[0.5rem] border-purple-500 ${isDragging ? 'text-green-300' : 'text-white'}`}
     >
-      {todo.task}
+      <div>
+        {todo.task}
+        {todo.completed ? '완료✅' : '아직❌'}
+        {todo.important ? '중요⭐' : '보통🌊'}
+      </div>
+      <div></div>
     </div>
   )
 }

--- a/components/ToDo/TodoItem.tsx
+++ b/components/ToDo/TodoItem.tsx
@@ -1,0 +1,33 @@
+import React, { useRef, useEffect } from 'react'
+import { useDrag } from 'react-dnd'
+import { Todo } from './todosServer'
+
+interface TodoItemProps {
+  todo: Todo
+}
+
+export default function TodoItem({ todo }: TodoItemProps) {
+  const todoRef = useRef<HTMLDivElement>(null)
+
+  const [{ isDragging }, drag] = useDrag(() => ({
+    type: 'TODO',
+    item: { id: todo.id },
+    collect: (monitor) => ({ isDragging: monitor.isDragging() }),
+  }))
+
+  // drag 함수가 변경될 때마다 ref.current에 연결
+  useEffect(() => {
+    if (todoRef.current) {
+      drag(todoRef.current)
+    }
+  }, [drag])
+
+  return (
+    <div
+      ref={todoRef}
+      className={`text-green-300 {isDragging ? 'opacity-50' : 'opacity-100'}`}
+    >
+      {todo.task}
+    </div>
+  )
+}

--- a/components/ToDo/todosServer.tsx
+++ b/components/ToDo/todosServer.tsx
@@ -55,3 +55,30 @@ export const updateTodo = async (
   if (error) throw new Error(error.message)
   return data
 }
+
+export const fetchThreeDaysTodo = async (
+  userEmail: string,
+  endDate: string,
+  startDate: string
+) => {
+  if (!userEmail) throw new Error('User email is required')
+  const { data, error } = await supabase
+    .from('todo')
+    .select('*')
+    .eq('user_email', userEmail)
+    .gte('date', startDate)
+    .lte('date', endDate)
+  if (error) throw new Error(error.message)
+  return data || []
+}
+
+export const fetchTodayTodo = async (userEmail: string, todayDate: string) => {
+  if (!userEmail) throw new Error('User email is required')
+  const { data, error } = await supabase
+    .from('todo')
+    .select('*')
+    .eq('user_email', userEmail)
+    .eq('date', todayDate)
+  if (error) throw new Error(error.message)
+  return data || []
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "naviynote",
       "version": "0.1.0",
       "dependencies": {
+        "@fullcalendar/daygrid": "^6.1.15",
+        "@fullcalendar/interaction": "^6.1.15",
+        "@fullcalendar/react": "^6.1.15",
         "@supabase/supabase-js": "^2.49.1",
         "next": "15.1.7",
         "next-auth": "^4.24.11",
@@ -147,6 +150,56 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fullcalendar/core": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.15.tgz",
+      "integrity": "sha512-BuX7o6ALpLb84cMw1FCB9/cSgF4JbVO894cjJZ6kP74jzbUZNjtwffwRdA+Id8rrLjT30d/7TrkW90k4zbXB5Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "preact": "~10.12.1"
+      }
+    },
+    "node_modules/@fullcalendar/core/node_modules/preact": {
+      "version": "10.12.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
+      "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/@fullcalendar/daygrid": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.15.tgz",
+      "integrity": "sha512-j8tL0HhfiVsdtOCLfzK2J0RtSkiad3BYYemwQKq512cx6btz6ZZ2RNc/hVnIxluuWFyvx5sXZwoeTJsFSFTEFA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.15"
+      }
+    },
+    "node_modules/@fullcalendar/interaction": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-6.1.15.tgz",
+      "integrity": "sha512-DOTSkofizM7QItjgu7W68TvKKvN9PSEEvDJceyMbQDvlXHa7pm/WAVtAc6xSDZ9xmB1QramYoWGLHkCYbTW1rQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.15"
+      }
+    },
+    "node_modules/@fullcalendar/react": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-6.1.15.tgz",
+      "integrity": "sha512-L0b9hybS2J4e7lq6G2CD4nqriyLEqOH1tE8iI6JQjAMTVh5JicOo5Mqw+fhU5bJ7hLfMw2K3fksxX3Ul1ssw5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.15",
+        "react": "^16.7.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.7.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "next": "15.1.7",
         "next-auth": "^4.24.11",
         "react": "^19.0.0",
+        "react-dnd": "^16.0.1",
+        "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^19.0.0",
         "zustand": "^5.0.3"
       },
@@ -896,6 +898,24 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
+    },
+    "node_modules/@react-dnd/asap": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-5.0.2.tgz",
+      "integrity": "sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/invariant": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-4.0.2.tgz",
+      "integrity": "sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/shallowequal": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz",
+      "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==",
+      "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -2228,6 +2248,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dnd-core": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-16.0.1.tgz",
+      "integrity": "sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/asap": "^5.0.1",
+        "@react-dnd/invariant": "^4.0.1",
+        "redux": "^4.2.0"
+      }
+    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -3126,7 +3157,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -3670,6 +3700,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
       }
     },
     "node_modules/human-signals": {
@@ -5684,6 +5723,45 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-dnd": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
+      "integrity": "sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/invariant": "^4.0.1",
+        "@react-dnd/shallowequal": "^4.0.1",
+        "dnd-core": "^16.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@types/hoist-non-react-statics": ">= 3.3.1",
+        "@types/node": ">= 12",
+        "@types/react": ">= 16",
+        "react": ">= 16.14"
+      },
+      "peerDependenciesMeta": {
+        "@types/hoist-non-react-statics": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dnd-html5-backend": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz",
+      "integrity": "sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==",
+      "license": "MIT",
+      "dependencies": {
+        "dnd-core": "^16.0.1"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
@@ -5700,7 +5778,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/read-cache": {
@@ -5724,6 +5801,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "*.{md,json}": "prettier --write"
   },
   "dependencies": {
+    "@fullcalendar/daygrid": "^6.1.15",
+    "@fullcalendar/interaction": "^6.1.15",
+    "@fullcalendar/react": "^6.1.15",
     "@supabase/supabase-js": "^2.49.1",
     "next": "15.1.7",
     "next-auth": "^4.24.11",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "next": "15.1.7",
     "next-auth": "^4.24.11",
     "react": "^19.0.0",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^19.0.0",
     "zustand": "^5.0.3"
   },

--- a/src/app/(pages)/todo/page.tsx
+++ b/src/app/(pages)/todo/page.tsx
@@ -1,9 +1,12 @@
+'use client'
 import ToDos from '@/components/ToDo/ToDos'
+import { DndProvider } from 'react-dnd'
+import { HTML5Backend } from 'react-dnd-html5-backend'
 
 export default function ToDoPage() {
   return (
-    <>
+    <DndProvider backend={HTML5Backend}>
       <ToDos />
-    </>
+    </DndProvider>
   )
 }


### PR DESCRIPTION
## 개요

- Todo page의 추가 기능 구현
- Todo의 UI 구현

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#12 
## PR 유형

어떤 변경 사항이 있나요?

- [x] API 설정 & 통신
- [ ] 버그를 수정
- [ ] 기타 수정(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] CSS 등 사용자 UI 디자인 변경(마크업 & 스타일링)
- [ ] 문서 수정
- [x] 새로운 기능을 개발
- [ ] 코드 리팩토링
- [ ] 세팅을 변경, 추가, 삭제

## 📝작업 내용

- 공통 Button 컴포넌트 생성
- 로딩 페이지 추가
- 캘린더 구현을 위해 'FullCalendar' 라이브러리 사용
- 캘린더 밖의 Todo를 drag해서 캘린더로 drop하는 기능 구현을 위해 'react-dnd' 라이브러리 사용
- Todo 페이지 UI 구현
  - 당일의 Todo
  - drag기능을 가진 날짜 없는 Todo
  - 캘린더에 특정 날짜 선택하면, 그 날의 전날, 당일, 다음날의 Todo
  - 모든 Todo의 수정, 삭제

![1](https://github.com/user-attachments/assets/c9732c16-2388-4b92-8b24-d5b5a13f3230)

![2](https://github.com/user-attachments/assets/5007d694-a98e-4d2b-97d1-3bc7f744365c)
