### PR TITLE
Todo와 Memo 연결 기능 중 버그, 빠진 기능 추가

### DIFF
--- a/components/Memo/memosServer.tsx
+++ b/components/Memo/memosServer.tsx
@@ -97,6 +97,7 @@ export const addMemo = async (memo: Omit<Memo, 'id'>, userEmail: string) => {
   }
   return { newMemo, memosUpdate }
 }
+
 export const deleteMemo = async (memoId: string, userEmail: string) => {
   if (!userEmail) throw new Error('User email is required')
   const { data, error } = await supabase
@@ -119,18 +120,20 @@ export const updateMemo = async (
 
   // 1.todo_id가 달라졌다면, 달라진 todo_id를 참고하고 있던 다른 memo(prevMemo)를 찾기
   if (updates.todo_id) {
-    const { data: prevMemo, error } = await supabase
+    const { data: prevMemos, error } = await supabase
       .from('memo')
       .select('id')
       .eq('todo_id', updates.todo_id)
       .neq('id', memoId)
       .eq('user_email', userEmail)
       .limit(1)
-      .single()
+
     if (error) throw new Error(error.message)
 
     // 2.memo를 찾아서 해당 memo의 todo_id를 null로 변경
-    if (prevMemo) {
+    if (prevMemos && prevMemos.length > 0) {
+      const prevMemo = prevMemos[0]
+
       const { data: prevMemoNull, error } = await supabase
         .from('memo')
         .update({ todo_id: null })

--- a/components/ToDo/TodoModal.tsx
+++ b/components/ToDo/TodoModal.tsx
@@ -303,7 +303,7 @@ const TodoModal = () => {
                 날짜 미정
               </Button>
             </div>
-            <label className="flex mb-[1rem]">
+            <label className="items-center flex mb-[1rem]">
               연결 메모 추가/수정
               <input
                 type="checkbox"
@@ -311,6 +311,13 @@ const TodoModal = () => {
                 className="ml-[0.5rem] self-center size-[1.5rem]"
                 onChange={(e) => setNewConnect(e.target.checked)}
               />
+              <Button
+                type="button"
+                className="ml-[2rem] rounded-md p-[0.5rem] bg-navy2"
+                onClick={NewConnectNull}
+              >
+                메모 연결 초기화
+              </Button>
             </label>
             <label>
               <div>
@@ -325,18 +332,10 @@ const TodoModal = () => {
                 )}
               </div>
             </label>
-
             {newConnect && (
               <div>
                 <div className="flex items-center mb-[1rem]">
                   <div>새로 연동할 메모 선택를 선택하세요</div>
-                  <Button
-                    type="button"
-                    className="ml-[2rem] rounded-md p-[0.5rem] bg-navy2"
-                    onClick={NewConnectNull}
-                  >
-                    메모 연결 초기화
-                  </Button>
                 </div>
                 <div className="flex">
                   <div className="mr-[1rem]">새로운 메모 :</div>

--- a/components/ToDo/todosServer.tsx
+++ b/components/ToDo/todosServer.tsx
@@ -71,7 +71,6 @@ export const addTodo = async (todo: Omit<Todo, 'id'>, userEmail: string) => {
       .neq('id', newTodo.id)
       .eq('user_email', userEmail)
       .limit(1)
-      .single()
     if (findError) throw new Error(findError.message)
 
     if (prevTodos && prevTodos.length > 0) {
@@ -110,18 +109,20 @@ export const updateTodo = async (
 
   // 1. memo_id가 달라졌다면, 달라진 memo_id를 참고하고 있던 다른 todo(prevTodo)를 찾기
   if (updates.memo_id) {
-    const { data: prevTodo, error } = await supabase
+    const { data: prevTodos, error } = await supabase
       .from('todo')
       .select('id')
       .eq('memo_id', updates.memo_id)
       .neq('id', todoId)
       .eq('user_email', userEmail)
       .limit(1)
-      .single()
+
     if (error) throw new Error(error.message)
 
     // 2. todo를 찾아서 해당 todo의 memo_id를 null로 변경
-    if (prevTodo) {
+    if (prevTodos && prevTodos.length > 0) {
+      const prevTodo = prevTodos[0]
+
       const { data: prevTodoNull, error } = await supabase
         .from('todo')
         .update({ memo_id: null })


### PR DESCRIPTION
## 개요

- Todo와 Memo 연결 기능 중 버그, 빠진 기능 추가

## #️⃣연관된 이슈

## PR 유형

어떤 변경 사항이 있나요?

- [ ] API 설정 & 통신
- [x] 버그를 수정
- [x] 기타 수정(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] CSS 등 사용자 UI 디자인 변경(마크업 & 스타일링)
- [ ] 문서 수정
- [x] 새로운 기능을 개발
- [ ] 코드 리팩토링
- [ ] 세팅을 변경, 추가, 삭제

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- memo와 todo에서 update시, todo_id나 memo_id의 중복 열 반환 문제를 해결
  `maybeSingle()  대신 select().limit(1)`
- todo 수정 시, memo_id 초기화 버튼 추가

### 스크린샷 (선택)
